### PR TITLE
allow to upload CWL workflows to Galaxy using the API

### DIFF
--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -304,6 +304,7 @@ class WorkflowContentsManager(UsesAnnotations):
             import_options.deduplicate_subworkflows = True
             as_dict = python_to_workflow(as_dict, galaxy_interface, workflow_directory=workflow_directory, import_options=import_options)
         elif workflow_class == "Workflow":
+            from galaxy.tools.cwl import workflow_proxy
             # create a temporary file for the workflow if it is provided
             # as JSON, to make it parseable by the WorkflowProxy
             if workflow_path is None:
@@ -312,12 +313,15 @@ class WorkflowContentsManager(UsesAnnotations):
                 json.dump(as_dict, f)
                 workflow_path = f.name
                 f.close()
+                if object_id:
+                    workflow_path += "#" + object_id
+                wf_proxy = workflow_proxy(workflow_path)
                 os.unlink(f.name)
-            from galaxy.tools.cwl import workflow_proxy
-            # TODO: consume and use object_id...
-            if object_id:
-                workflow_path += "#" + object_id
-            wf_proxy = workflow_proxy(workflow_path)
+            else:
+                # TODO: consume and use object_id...
+                if object_id:
+                    workflow_path += "#" + object_id
+                wf_proxy = workflow_proxy(workflow_path)
             tool_reference_proxies = wf_proxy.tool_reference_proxies()
             for tool_reference_proxy in tool_reference_proxies:
                 # TODO: Namespace IDS in workflows.

--- a/lib/galaxy/managers/workflows.py
+++ b/lib/galaxy/managers/workflows.py
@@ -304,6 +304,15 @@ class WorkflowContentsManager(UsesAnnotations):
             import_options.deduplicate_subworkflows = True
             as_dict = python_to_workflow(as_dict, galaxy_interface, workflow_directory=workflow_directory, import_options=import_options)
         elif workflow_class == "Workflow":
+            # create a temporary file for the workflow if it is provided
+            # as JSON, to make it parseable by the WorkflowProxy
+            if workflow_path is None:
+                import tempfile, os
+                f = tempfile.NamedTemporaryFile(delete=False)
+                json.dump(as_dict, f)
+                workflow_path = f.name
+                f.close()
+                os.unlink(f.name)
             from galaxy.tools.cwl import workflow_proxy
             # TODO: consume and use object_id...
             if object_id:


### PR DESCRIPTION
before this quickfix, the API would crash because it would
expect the workflow file path. this is a quickfix, there is
probably a much cleaner way to do this (implement this in the
WorkflowProxy?)