### PR TITLE
set CWL workflow name to label, not file path

### DIFF
--- a/lib/galaxy/tools/cwl/parser.py
+++ b/lib/galaxy/tools/cwl/parser.py
@@ -757,7 +757,7 @@ class WorkflowProxy(object):
         return input_connections_by_step
 
     def to_dict(self):
-        name = os.path.basename(self._workflow_path or 'TODO - derive a name from ID')
+        name = os.path.basename(self._workflow.tool.get('label') or self._workflow_path or 'TODO - derive a name from ID')
         steps = {}
 
         step_proxies = self.step_proxies()


### PR DESCRIPTION
If a label has been defined for the CWL file, use this as the name for the workflow instead of the file path