### PR TITLE
Various fixes and enhancements

### DIFF
--- a/lib/galaxy/tool_util/cwl/util.py
+++ b/lib/galaxy/tool_util/cwl/util.py
@@ -394,6 +394,9 @@ def invocation_to_output(invocation, history_id, output_id):
     elif output_id in invocation["output_collections"]:
         collection = invocation["output_collections"][output_id]
         galaxy_output = GalaxyOutput(history_id, "dataset_collection", collection["id"], None)
+    elif output_id in invocation["output_values"]:
+        output_value = invocation["output_values"][output_id]
+        galaxy_output = GalaxyOutput(None, "raw_value", output_value, None)
     else:
         raise Exception(f"Failed to find output with label [{output_id}] in [{invocation}]")
 
@@ -435,7 +438,9 @@ def output_to_cwl_json(
             with open(dataset_dict["path"]) as f:
                 return json.safe_load(f)
 
-    if output_metadata["history_content_type"] == "dataset":
+    if galaxy_output.history_content_type == "raw_value":
+        return galaxy_output.history_content_id
+    elif output_metadata["history_content_type"] == "dataset":
         ext = output_metadata["file_ext"]
         assert output_metadata["state"] == "ok"
         if ext == "expression.json":

--- a/lib/galaxy/workflow/modules.py
+++ b/lib/galaxy/workflow/modules.py
@@ -1714,7 +1714,6 @@ class ToolModule(WorkflowModule):
                 hda_references.append(value)
                 if value.ext == "expression.json":
                     with open(value.file_name, "r") as f:
-                        import json
                         # OUR safe_loads won't work, will not load numbers, etc...
                         return json.load(f)
                 else:

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -295,6 +295,25 @@ class CwlWorkflowRun(CwlRun):
         )
 
 
+def load_conformance_tests(directory, path="conformance_tests.yaml"):
+    conformance_tests_path = os.path.join(directory, path)
+    with open(conformance_tests_path, "r") as f:
+        conformance_tests = yaml.load(f)
+
+    expanded_conformance_tests = []
+    for i, conformance_test in enumerate(conformance_tests):
+        if "$import" in conformance_test:
+            import_path = conformance_test["$import"]
+            expanded_conformance_tests.extend(load_conformance_tests(directory, import_path))
+        else:
+            subdirectory, _ = os.path.split(path)
+            if subdirectory:
+                conformance_test["relative_path"] = os.path.join(directory, subdirectory)
+            expanded_conformance_tests.append(conformance_test)
+
+    return expanded_conformance_tests
+
+
 class CwlPopulator(object):
 
     def __init__(self, dataset_populator, workflow_populator):
@@ -400,7 +419,7 @@ class CwlPopulator(object):
             return CwlWorkflowRun(self.dataset_populator, self.workflow_populator, history_id, workflow_id, invocation_id)
 
     def get_conformance_test(self, version, doc):
-        conformance_tests = yaml.load(open(os.path.join(CWL_TOOL_DIRECTORY, str(version), "conformance_tests.yaml"), "r"))
+        conformance_tests = load_conformance_tests(os.path.join(CWL_TOOL_DIRECTORY, str(version)))
         for test in conformance_tests:
             if test.get("doc") == doc:
                 return test
@@ -408,13 +427,14 @@ class CwlPopulator(object):
 
     def run_conformance_test(self, version, doc):
         test = self.get_conformance_test(version, doc)
-        if version < "v1.1":
-            tool = os.path.join(CWL_TOOL_DIRECTORY, test["tool"])
-            job = os.path.join(CWL_TOOL_DIRECTORY, test["job"])
+        if "relative_path" in test:
+            directory = test["relative_path"]
+        elif version < "v1.1":
+            directory = CWL_TOOL_DIRECTORY
         else:
-            tool = os.path.join(CWL_TOOL_DIRECTORY, version, test["tool"])
-            job = os.path.join(CWL_TOOL_DIRECTORY, version, test["job"])
-
+            directory = os.path.join(CWL_TOOL_DIRECTORY, version)
+        tool = os.path.join(directory, test["tool"])
+        job = os.path.join(directory, test["job"])
         try:
             run = self.run_cwl_job(tool, job)
         except Exception:

--- a/lib/galaxy_test/base/populators.py
+++ b/lib/galaxy_test/base/populators.py
@@ -215,9 +215,12 @@ class CwlRun:
         galaxy_output = self._output_name_to_object(output_name)
 
         def get_metadata(history_content_type, content_id):
-            if history_content_type == "dataset":
+            if history_content_type == "raw_value":
+                return {}
+            elif history_content_type == "dataset":
                 return self.dataset_populator.get_history_dataset_details(self.history_id, dataset_id=content_id)
             else:
+                assert history_content_type == "dataset_collection"
                 # Don't wait - we've already done that, history might be "new"
                 return self.dataset_populator.get_history_collection_details(self.history_id, content_id=content_id, wait=False)
 

--- a/test/unit/tools/cwl_tools/conformance_to_test_cases.py
+++ b/test/unit/tools/cwl_tools/conformance_to_test_cases.py
@@ -411,6 +411,8 @@ def main():
     conformance_tests = load_conformance_tests(os.path.join(THIS_DIRECTORY, version))
 
     green_tests_list = GREEN_TESTS[version]
+    green_tests_found = set()
+    all_tests_found = set()
 
     tests = ""
     green_tests = ""
@@ -442,6 +444,10 @@ def main():
             marks += "    @pytest.mark.red\n"
         if is_regression:
             marks += "    @pytest.mark.regression\n"
+
+        if "command_line_tool" not in tags and "workflow" not in tags and "expression_tool" not in tags:
+            print("PROBLEM - test tagged with neither command_line_tool, expression_tool, nor workflow [%s]" % label)
+
         template_kwargs = {
             'version_simple': version_simple,
             'version': version,
@@ -465,6 +471,12 @@ def main():
                 red_required_tests += test_body
         if is_regression:
             regression_tests += test_body
+
+        if label in all_tests_found:
+            print("PROBLEM - Duplicate label found [%s]" % label)
+        all_tests_found.add(label)
+        if is_green:
+            green_tests_found.add(label)
 
     def generate_test_file(tests):
         return TEST_FILE_TEMPLATE.safe_substitute({
@@ -502,6 +514,9 @@ def main():
     write_test_cases(required_red_test_file_contents, "required_red")
     write_test_cases(required_green_test_file_contents, "required_green")
 
+    for green_test in green_tests_list:
+        if green_test not in green_tests_found:
+            print("PROBLEM - Failed to find annotated green test [%s]" % green_test)
 
 if __name__ == "__main__":
     main()

--- a/test/unit/tools/cwl_tools/v1.1/conformance_tests.yaml
+++ b/test/unit/tools/cwl_tools/v1.1/conformance_tests.yaml
@@ -862,7 +862,7 @@
   label: metadata
   id: 63
   doc: Test metadata
-  tags: [ required ]
+  tags: [ required, command_line_tool ]
 
 - job: tests/formattest-job.json
   output:
@@ -1877,7 +1877,7 @@
        checksum: "sha1$7d5ca8c0c03e883c56c4eb1ef6f6bb9bccad4d86"
        size: 8
   tool: tests/envvar3.cwl
-  label: env_home_tmpdir_docker
+  label: env_home_tmpdir_docker_no_return_code
   id: 134
   doc: Test $HOME and $TMPDIR are set correctly in Docker without using return code
   tags: [ shell_command, command_line_tool ]
@@ -2877,7 +2877,7 @@
   tool: tests/networkaccess2.cwl
   label: networkaccess_disabled
   doc: Test networkaccess is disabled by default
-  tags: [ networkaccess ]
+  tags: [ networkaccess, command_line_tool ]
   id: 224
 
 - job: tests/stage-array-job.json
@@ -2973,7 +2973,7 @@
   tool: tests/initialworkdir-glob-fullpath.cwl
   doc: Test output of InitialWorkDir
   label: initial_work_dir_output
-  tags: [ initial_work_dir ]
+  tags: [ initial_work_dir, command_line_tool ]
   id: 230
 
 - job: tests/initialworkdirrequirement-docker-out-job.json
@@ -2992,7 +2992,7 @@
   tool: tests/initialworkdir-glob-fullpath.cwl
   doc: Test if full paths are allowed in glob
   label: glob_full_path
-  tags: [ initial_work_dir ]
+  tags: [ initial_work_dir, command_line_tool ]
   id: 231
 
 - job: tests/empty.json
@@ -3000,7 +3000,7 @@
   tool: tests/glob-path-error.cwl
   doc: Test fail trying to glob outside output directory
   label: fail_glob_outside_output_dir
-  tags: [ required ]
+  tags: [ required, command_line_tool ]
   id: 232
 
 - job: tests/empty.json
@@ -3014,6 +3014,7 @@
       "baesname": "symlink.txt"
       "checksum": "sha1$cd28ec34f3f9425aca544b6332453708e8aaa82a"
   should_fail: true
+  tags: [ command_line_tool ]
   id: 233
 
 - job: tests/empty.json
@@ -3027,12 +3028,13 @@
       "basename": "symlink.txt"
       "checksum": "sha1$cd28ec34f3f9425aca544b6332453708e8aaa82a"
   id: 234
+  tags: [ command_line_tool ]
 
 - job: tests/empty.json
   tool: tests/inp_update_wf.cwl
   doc: inplace update has side effect on file content
   label: inplace_update_on_file_content
-  tags: [ inplace_update ]
+  tags: [ inplace_update, workflow ]
   output:
     a: 4
     b: 4
@@ -3042,7 +3044,7 @@
   tool: tests/inpdir_update_wf.cwl
   doc: inplace update has side effect on directory content
   label: inplace_update_on_dir_content
-  tags: [ inplace_update ]
+  tags: [ inplace_update, workflow ]
   output: {
     a: [
             {


### PR DESCRIPTION
- Fix running recursive conformance tests imported introduced in CWL 1.2 test suite (previous fix had a bug).
- When pulling workflow output CWL outputs, handle non-data/non-collection datatypes (i.e. simple values). Needed for null and string outputs of a conditional test case.
- When evaluating expressions for workflows, walk inputs not consumed by the underlying tool also (kind of messy).
- Add pytest marks for each test tag found in conformance_tests.yaml when generating Python test suites, allows for much more flexible testing combinations.
- When generating test suites in Python suite, print some common problems so we can fix up the source test specifications.
- Bring in fixes for the cwl v1.1 conformance tests file (xref https://github.com/common-workflow-language/cwl-v1.1/pull/72).
 